### PR TITLE
Loosen dependency on Pronto.

### DIFF
--- a/pronto-rails_best_practices.gemspec
+++ b/pronto-rails_best_practices.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -- {spec}/*`.split("\n")
   s.require_paths = ['lib']
 
-  s.add_dependency 'pronto', '~> 0.3.0'
+  s.add_dependency 'pronto', '~> 0.4.0'
   s.add_dependency 'rails_best_practices', '~> 1.15.0'
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
The current gem indicates that it depends on `~> 0.1.0`. Should this instead be `~> 0.4`?
